### PR TITLE
Fix for cookie deletion test for go1.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ _testmain.go
 cmd/httpbin/httpbin
 
 vendor
+.vscode

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,13 @@ sudo: false
 language: go
 go: go1.9
 install:
-  - mkdir -p $GOPATH/src/github.com/ahmetd
-  - ln -s $GOPATH/src/github.com/dbenque/go-httpbin $GOPATH/src/github.com/ahmetd/go-httpbin
-  - curl https://glide.sh/get | sh
-  - glide install
+  - mkdir -p $GOPATH/src/github.com/ahmetb
+  - ln -s $GOPATH/src/github.com/dbenque/go-httpbin $GOPATH/src/github.com/ahmetb/go-httpbin
   - go get -u github.com/golang/lint/golint
 script:
   - test -z "$(gofmt -s -l -w . | tee /dev/stderr)"
   - test -z "$(golint . | tee /dev/stderr)"
   - go vet -v .
+  - curl https://glide.sh/get | sh
+  - glide install
   - go test -v -cover  ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 sudo: false
 language: go
-go: go1.7
+go: go1.9
 install:
+  - mkdir -p $GOPATH/src/github.com/ahmetd
+  - ln -s $GOPATH/src/github.com/dbenque/go-httpbin $GOPATH/src/github.com/ahmetd/go-httpbin
+  - curl https://glide.sh/get | sh
+  - glide install
   - go get -u github.com/golang/lint/golint
-  - go get github.com/gorilla/mux
-  - go get github.com/pkg/errors
-  - go get github.com/stretchr/testify/require
 script:
   - test -z "$(gofmt -s -l -w . | tee /dev/stderr)"
   - test -z "$(golint . | tee /dev/stderr)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ sudo: false
 language: go
 go: go1.9
 install:
-  - mkdir -p $GOPATH/src/github.com/ahmetb
-  - ln -s $GOPATH/src/github.com/dbenque/go-httpbin $GOPATH/src/github.com/ahmetb/go-httpbin
   - go get -u github.com/golang/lint/golint
 script:
   - test -z "$(gofmt -s -l -w . | tee /dev/stderr)"

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,6 @@
-hash: 4bd1a8e2ca78b71807c2ad50d56d8522d123a5ed79536856ef3071b44a54496b
-updated: 2017-03-12T09:06:52.165140388-07:00
+hash: 7a39c9c07050489fbd69126b112f5f2cd2686e9a0506ffc294d06213322a8fe0
+updated: 2017-11-29T23:10:11.45869886+01:00
 imports:
-- name: github.com/ahmetb/go-httpbin
-  version: 4ca994120406564e3a6ac8a177c194ac9ca3ae8b
 - name: github.com/gorilla/context
   version: 08b5f424b9271eedf6f9f0ce86cb9396ed337a42
 - name: github.com/gorilla/mux

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,6 +1,5 @@
 package: github.com/arschles/go-httpbin
 import:
-- package: github.com/ahmetb/go-httpbin
 - package: github.com/gorilla/mux
   version: ~1.3.0
 - package: github.com/pkg/errors

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -14,6 +14,7 @@ import (
 	"net/http/cookiejar"
 	"net/http/httptest"
 	"net/url"
+	"runtime"
 	"testing"
 	"time"
 
@@ -401,10 +402,19 @@ func TestDeleteCookies(t *testing.T) {
 	for _, c := range cj.Cookies(u) {
 		cs = append(cs, c.String())
 	}
-	require.Contains(t, cs, "k1=")
-	require.Contains(t, cs, "k2=")
-	require.Contains(t, cs, "k3=v3")
-	require.Equal(t, 3, len(cs))
+	if runtime.Version() >= "go1.8" {
+		require.NotContains(t, cs, "k1=")
+		require.NotContains(t, cs, "k2=")
+		require.NotContains(t, cs, "k1=v1")
+		require.NotContains(t, cs, "k2=v2")
+		require.Contains(t, cs, "k3=v3")
+		require.Equal(t, 1, len(cs))
+	} else {
+		require.Contains(t, cs, "k1=")
+		require.Contains(t, cs, "k2=")
+		require.Contains(t, cs, "k3=v3")
+		require.Equal(t, 3, len(cs))
+	}
 }
 
 func TestDrip_code(t *testing.T) {


### PR DESCRIPTION
Update the test that is go version dependent
Fix the glide dependency to remove self vendoring of the project
Update Travis file for go 1.9