### PR TITLE
Introduce support for POST method

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 
-	"github.com/ahmetb/go-httpbin"
+	httpbin "github.com/ahmetb/go-httpbin"
 )
 
 func ExampleGetMux_httptest() {

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 7a39c9c07050489fbd69126b112f5f2cd2686e9a0506ffc294d06213322a8fe0
-updated: 2017-11-29T23:10:11.45869886+01:00
+hash: dfcfc8201cfb1598706b482f1da8fcdc6c6513aeb1933308a7f0d5736a3c32ab
+updated: 2018-05-31T23:58:25.975525+03:00
 imports:
 - name: github.com/gorilla/context
   version: 08b5f424b9271eedf6f9f0ce86cb9396ed337a42
@@ -17,7 +17,7 @@ testImports:
   subpackages:
   - difflib
 - name: github.com/stretchr/testify
-  version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
+  version: 12b6f73e6084dad08a7c6e575284b177ecafbc71
   subpackages:
   - assert
   - require

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,4 +1,4 @@
-package: github.com/arschles/go-httpbin
+package: github.com/ahmetb/go-httpbin
 import:
 - package: github.com/gorilla/mux
   version: ~1.3.0

--- a/glide.yaml
+++ b/glide.yaml
@@ -6,6 +6,6 @@ import:
   version: ~0.8.0
 testImport:
 - package: github.com/stretchr/testify
-  version: ~1.1.4
+  version: ~1.2.1
   subpackages:
   - require

--- a/handlers.go
+++ b/handlers.go
@@ -51,7 +51,7 @@ func GetMux() *mux.Router {
 	r.HandleFunc(`/redirect/{n:[\d]+}`, RedirectHandler).Methods(http.MethodGet, http.MethodHead)
 	r.HandleFunc(`/absolute-redirect/{n:[\d]+}`, AbsoluteRedirectHandler).Methods(http.MethodGet, http.MethodHead)
 	r.HandleFunc(`/redirect-to`, RedirectToHandler).Methods(http.MethodGet, http.MethodHead).Queries("url", "{url:.+}")
-	r.HandleFunc(`/status/{code:[\d]+}`, StatusHandler).Methods(supportedMethods...)
+	r.HandleFunc(`/status/{code:[\d]+}`, StatusHandler)
 	r.HandleFunc(`/bytes/{n:[\d]+}`, BytesHandler).Methods(http.MethodGet, http.MethodHead)
 	r.HandleFunc(`/delay/{n:\d+(?:\.\d+)?}`, DelayHandler).Methods(http.MethodGet, http.MethodHead)
 	r.HandleFunc(`/stream/{n:[\d]+}`, StreamHandler).Methods(http.MethodGet, http.MethodHead)

--- a/handlers.go
+++ b/handlers.go
@@ -40,6 +40,16 @@ var (
 
 // GetMux returns the mux with handlers for httpbin endpoints registered.
 func GetMux() *mux.Router {
+	supportedMethods := []string{
+		http.MethodHead,
+		http.MethodGet,
+		http.MethodPost,
+		http.MethodPatch,
+		http.MethodDelete,
+		http.MethodTrace,
+		http.MethodOptions,
+	}
+
 	r := mux.NewRouter()
 	r.HandleFunc(`/`, HomeHandler).Methods(http.MethodGet, http.MethodHead)
 	r.HandleFunc(`/ip`, IPHandler).Methods(http.MethodGet, http.MethodHead)
@@ -50,7 +60,7 @@ func GetMux() *mux.Router {
 	r.HandleFunc(`/redirect/{n:[\d]+}`, RedirectHandler).Methods(http.MethodGet, http.MethodHead)
 	r.HandleFunc(`/absolute-redirect/{n:[\d]+}`, AbsoluteRedirectHandler).Methods(http.MethodGet, http.MethodHead)
 	r.HandleFunc(`/redirect-to`, RedirectToHandler).Methods(http.MethodGet, http.MethodHead).Queries("url", "{url:.+}")
-	r.HandleFunc(`/status/{code:[\d]+}`, StatusHandler)
+	r.HandleFunc(`/status/{code:[\d]+}`, StatusHandler).Methods(supportedMethods...)
 	r.HandleFunc(`/bytes/{n:[\d]+}`, BytesHandler).Methods(http.MethodGet, http.MethodHead)
 	r.HandleFunc(`/delay/{n:\d+(?:\.\d+)?}`, DelayHandler).Methods(http.MethodGet, http.MethodHead)
 	r.HandleFunc(`/stream/{n:[\d]+}`, StreamHandler).Methods(http.MethodGet, http.MethodHead)

--- a/handlers.go
+++ b/handlers.go
@@ -647,12 +647,13 @@ func getImg() image.Image {
 
 func parseData(r *http.Request) ([]byte, error) {
 	if r.Body == nil {
-		return []byte{}, nil
+		return nil, nil
 	}
+	defer r.Body.Close()
 
 	data, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		return []byte{}, err
+		return nil, err
 	}
 
 	return data, nil

--- a/handlers.go
+++ b/handlers.go
@@ -40,15 +40,6 @@ var (
 
 // GetMux returns the mux with handlers for httpbin endpoints registered.
 func GetMux() *mux.Router {
-	supportedMethods := []string{
-		http.MethodHead,
-		http.MethodGet,
-		http.MethodPost,
-		http.MethodPatch,
-		http.MethodDelete,
-		http.MethodTrace,
-		http.MethodOptions,
-	}
 
 	r := mux.NewRouter()
 	r.HandleFunc(`/`, HomeHandler).Methods(http.MethodGet, http.MethodHead)

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -211,7 +211,15 @@ func TestStatus_assertValidCodes(t *testing.T) {
 	srv := testServer()
 	defer srv.Close()
 
-	methods := []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodDelete}
+	methods := []string{
+		http.MethodGet,
+		http.MethodPost,
+		http.MethodPut,
+		http.MethodDelete,
+		http.MethodPatch,
+		http.MethodOptions,
+		http.MethodTrace,
+	}
 
 	codes := []int{200, 201, 202, 203, 204, 205, 206, 207, 208, 226,
 		300, 301, 302, 303, 304, 305, 307, 308, 400, 401, 402, 403, 404, 405, 406,

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -39,28 +39,36 @@ func noRedirectClient() *http.Client {
 }
 
 func noFollowGet(cl *http.Client, u string) (*http.Response, error) {
-	resp, err := cl.Get(u)
+	return noFollow("GET", cl, u)
+}
+
+func noFollow(method string, cl *http.Client, u string) (*http.Response, error) {
+	req, err := http.NewRequest(method, u, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: method=%s url=%q error=%v", method, u, err)
+	}
+	resp, err := cl.Do(req)
 	if err != nil {
 		e, ok := err.(*url.Error)
 		if ok && e.Err != errNoFollow {
-			return nil, fmt.Errorf("failed to get: url=%q error=%v", u, err)
+			return nil, fmt.Errorf("failed to get: method=%s url=%q error=%v", method, u, err)
 		}
 	}
 	return resp, nil
 }
 
 func get(t *testing.T, url string) []byte {
-	return req(t, url, "GET")
+	return req(t, url, "GET", "")
 }
 
-func post(t *testing.T, url string) []byte {
-	return req(t, url, "POST")
+func post(t *testing.T, url, body string) []byte {
+	return req(t, url, "POST", body)
 }
 
-func req(t *testing.T, url, method string) []byte {
+func req(t *testing.T, url, method, body string) []byte {
 	cl := &http.Client{}
 
-	r, err := http.NewRequest(method, url, nil)
+	r, err := http.NewRequest(method, url, bytes.NewReader([]byte(body)))
 	require.Nil(t, err, "cannot create request")
 
 	resp, err := cl.Do(r)
@@ -145,6 +153,31 @@ func TestGet(t *testing.T) {
 	require.NotEmpty(t, v.Headers)
 	require.NotEmpty(t, v.Origin)
 }
+func TestPost(t *testing.T) {
+	srv := testServer()
+	defer srv.Close()
+
+	data := `{[{"k1": "v1"}]}`
+
+	b := post(t, srv.URL+"/post?k1=v1&k1=v2&k3=v3", data)
+	v := struct {
+		Args    map[string]interface{} `json:"args"`
+		Headers map[string]string      `json:"headers"`
+		Origin  string                 `json:"origin"`
+		Data    string                 `json:"data"`
+		JSON    interface{}            `json:"json"`
+	}{}
+	require.Nil(t, json.Unmarshal(b, &v))
+	require.NotEmpty(t, v.Args, "args empty")
+	require.EqualValues(t, map[string]interface{}{
+		"k1": []interface{}{"v1", "v2"},
+		"k3": "v3",
+	}, v.Args)
+
+	require.EqualValues(t, data, v.Data)
+	require.NotEmpty(t, v.Headers)
+	require.NotEmpty(t, v.Origin)
+}
 
 func TestRedirect(t *testing.T) {
 	srv := testServer()
@@ -179,16 +212,20 @@ func TestStatus_assertValidCodes(t *testing.T) {
 	srv := testServer()
 	defer srv.Close()
 
+	methods := []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodDelete}
+
 	codes := []int{200, 201, 202, 203, 204, 205, 206, 207, 208, 226,
 		300, 301, 302, 303, 304, 305, 307, 308, 400, 401, 402, 403, 404, 405, 406,
 		407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 418, 422, 423, 424,
 		426, 428, 429, 431, 451, 500, 501, 502, 503, 504, 505, 506, 507, 508, 510, 511}
 
-	for _, code := range codes {
-		u := fmt.Sprintf("%s/status/%d", srv.URL, code)
-		resp, err := noFollowGet(noRedirectClient(), u)
-		require.Nil(t, err, u)
-		require.Equal(t, code, resp.StatusCode, u)
+	for _, method := range methods {
+		for _, code := range codes {
+			u := fmt.Sprintf("%s/status/%d", srv.URL, code)
+			resp, err := noFollow(method, noRedirectClient(), u)
+			require.Nil(t, err, u)
+			require.Equal(t, code, resp.StatusCode, "%s %s", method, u)
+		}
 	}
 }
 

--- a/types.go
+++ b/types.go
@@ -31,6 +31,17 @@ type getResponse struct {
 	Args map[string]interface{} `json:"args"`
 }
 
+type postResponse struct {
+	headersResponse
+	ipResponse
+	URL   string                 `json:"url"`
+	Args  map[string]interface{} `json:"args"`
+	Data  string                 `json:"data"`
+	Files map[string]string      `json:"files"`
+	Form  map[string]interface{} `json:"form"`
+	JSON  interface{}            `json:"json"`
+}
+
 type gzipResponse struct {
 	headersResponse
 	ipResponse


### PR DESCRIPTION
Hello, 

I try to replace httpbin.org with go-httpbin, running locally. However some things were missing and I decided to implement them. So this PR includes the following changes:

1.  `/status` now support any method (not only GET, HEAD), similar to httpbin.org 
2.  Partially implement `/post`, with everything GET has, plus **data** and **JSON**. Files and Form are missing.