### PR TITLE
Specify us-ascii for XML test

### DIFF
--- a/data.go
+++ b/data.go
@@ -15,7 +15,7 @@ const (
       </div>
   </body>
 </html>`
-	xmlData = `<?xml version='1.0'?>
+	xmlData = `<?xml version='1.0' encoding='us-ascii'?>
 
 <!--  A SAMPLE set of slides  -->
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,12 +1,12 @@
-hash: dfcfc8201cfb1598706b482f1da8fcdc6c6513aeb1933308a7f0d5736a3c32ab
-updated: 2018-05-31T23:58:25.975525+03:00
+hash: c074de462b0a6e667f5766563335c9a2eaf1516145f761c578e68563783833e7
+updated: 2019-06-07T11:58:06.044198393-07:00
 imports:
 - name: github.com/gorilla/context
   version: 08b5f424b9271eedf6f9f0ce86cb9396ed337a42
 - name: github.com/gorilla/mux
   version: 392c28fe23e1c45ddba891b0320b3b5df220beea
 - name: github.com/pkg/errors
-  version: 645ef00459ed84a119197bfb8d8205042c6df63d
+  version: ba968bfe8b2f7e042a574c888954fccecfa385b4
 testImports:
 - name: github.com/davecgh/go-spew
   version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
@@ -17,7 +17,33 @@ testImports:
   subpackages:
   - difflib
 - name: github.com/stretchr/testify
-  version: 12b6f73e6084dad08a7c6e575284b177ecafbc71
+  version: f35b8ab0b5a2cef36673838d662e249dd9c94686
   subpackages:
   - assert
   - require
+- name: golang.org/x/net
+  version: 461777fb6f67e8cb9d70cda16573678d085a74cf
+  subpackages:
+  - html
+  - html/atom
+  - html/charset
+- name: golang.org/x/text
+  version: 342b2e1fbaa52c93f31447ad2c6abc048c63e475
+  subpackages:
+  - encoding
+  - encoding/charmap
+  - encoding/htmlindex
+  - encoding/internal
+  - encoding/internal/identifier
+  - encoding/japanese
+  - encoding/korean
+  - encoding/simplifiedchinese
+  - encoding/traditionalchinese
+  - encoding/unicode
+  - internal/language
+  - internal/language/compact
+  - internal/tag
+  - internal/utf8internal
+  - language
+  - runes
+  - transform

--- a/glide.yaml
+++ b/glide.yaml
@@ -9,3 +9,4 @@ testImport:
   version: ~1.2.1
   subpackages:
   - require
+- package: golang.org/x/net/html/charset

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -20,6 +20,8 @@ import (
 
 	"github.com/ahmetb/go-httpbin"
 	"github.com/stretchr/testify/require"
+
+	"golang.org/x/net/html/charset"
 )
 
 var (
@@ -709,9 +711,9 @@ func TestXML(t *testing.T) {
 		Slides  []slide  `xml:"slide"`
 	}
 	var v val
-	b, err := ioutil.ReadAll(resp.Body)
-	require.Nil(t, err)
-	require.Nil(t, xml.Unmarshal(b, &v))
+	decoder := xml.NewDecoder(resp.Body)
+	decoder.CharsetReader = charset.NewReaderLabel
+	require.Nil(t, decoder.Decode(&v))
 	require.Equal(t, val{
 		XMLName: xml.Name{Local: "slideshow"},
 		Title:   "Sample Slide Show",


### PR DESCRIPTION
This aligns go-httpbin with httpbin.org.