### PR TITLE
Check version more robustly in TestDeleteCookies

### DIFF
--- a/handlers_test.go
+++ b/handlers_test.go
@@ -448,7 +448,7 @@ func TestDeleteCookies(t *testing.T) {
 	for _, c := range cj.Cookies(u) {
 		cs = append(cs, c.String())
 	}
-	if runtime.Version() >= "go1.8" {
+	if runtime.Version() >= "go1.8" || runtime.Version() >= "go1.10" {
 		require.NotContains(t, cs, "k1=")
 		require.NotContains(t, cs, "k2=")
 		require.NotContains(t, cs, "k1=v1")


### PR DESCRIPTION
Previously this failed due to the two-digit subversion.  Fixes #26.