### PR TITLE
Add missing Content-Type header on JSON responses

### DIFF
--- a/util.go
+++ b/util.go
@@ -12,6 +12,7 @@ import (
 func writeJSON(w io.Writer, v interface{}) error {
 	e := json.NewEncoder(w)
 	e.SetIndent("", "  ")
+	writer.Header().Set("Content-Type", "application/json")
 	return errors.Wrap(e.Encode(v), "failed to encode JSON")
 }
 


### PR DESCRIPTION
Hi there, thanks for the awesome package! I previously relied on using httpbin.org in tests but prefer having a local test server.

In some of my tests, i asserted that the response of some endpoints is status 200 and content type is "application/json".

Migrating to this package, these tests failed because the content type is not set.

As far as I am concerned this should be fine, right?

Sincerely!